### PR TITLE
Property 번역어 통일

### DIFF
--- a/1-js/08-prototypes/01-prototype-inheritance/article.md
+++ b/1-js/08-prototypes/01-prototype-inheritance/article.md
@@ -2,13 +2,13 @@
 
 우리는 종종 프로그래밍을 하다 보면 확장을 하기를 원합니다. 
 
-예를 들어, 메서드와 속성을 가지고 있는 `user`라는 객체를 가지고 있다고 해 봅시다. 그리고 우리는 이 객체에 살짝 변화를 주면서 `admin`과 `guest`를 추가하고 싶다고 해 봅시다. 우리는 메서드를 복사/구현하는 것이 아니라 `user`가 가지고 있는 것을 재사용하고 싶을 것입니다. 이 위에 새로운 객체를 만드는 것이죠. 
+예를 들어, 메서드와 프로퍼티를 가지고 있는 `user`라는 객체를 가지고 있다고 해 봅시다. 그리고 우리는 이 객체에 살짝 변화를 주면서 `admin`과 `guest`를 추가하고 싶다고 해 봅시다. 우리는 메서드를 복사/구현하는 것이 아니라 `user`가 가지고 있는 것을 재사용하고 싶을 것입니다. 이 위에 새로운 객체를 만드는 것이죠. 
 
 *원형 상속 Prototypal inheritance*은 바로 그것을 돕는 언어 특징입니다. 
 
 ## [[Prototype]]
 
-자바스크립트에서, 객체는 `[[Prototype]]`이라는 숨겨진 속성을 가지고 있습니다(specification에 명명되어 있듯이). 이 속성은 `null`이거나 다른 객체를 참조하고 있습니다. 그 객체가 바로 "원형"이라 불리는 객체입니다. 
+자바스크립트에서, 객체는 `[[Prototype]]`이라는 숨겨진 프로퍼티를 가지고 있습니다(specification에 명명되어 있듯이). 이 프로퍼티는 `null`이거나 다른 객체를 참조하고 있습니다. 그 객체가 바로 "원형"이라 불리는 객체입니다. 
 
 ![prototype](object-prototype-empty.svg)
 
@@ -39,7 +39,7 @@ It exists for historical reasons, in modern language it is replaced with functio
 By the specification, `__proto__` must only be supported by browsers, but in fact all environments including server-side support it. For now, as `__proto__` notation is a little bit more intuitively obvious, we'll use it in the examples.
 ```
 
-만약 우리가 `rabbit` 속성을 찾는다면, 그리고 그게 없다면, 자바스크립트는 자동으로 `animal`에서 그것을 찾을 것입니다.
+만약 우리가 `rabbit` 프로퍼티를 찾는다면, 그리고 그게 없다면, 자바스크립트는 자동으로 `animal`에서 그것을 찾을 것입니다.
 
 예를 들어:
 
@@ -64,13 +64,13 @@ alert( rabbit.jumps ); // true
 
 여기`(*)`가 표시된 줄에서 `animal`을 `rabbit`의 원형으로 설정하고 있습니다.
 
-이후, `alert`가 `(**)`에서 `rabbit.eats`속성을 읽으려 할 때, `rabbit`에서 읽지 않습니다. 즉, 자바스크립트는 `[[Prototype]]`을 따라가서 참조하고 `animal`에서 해당 속성을 찾아냅니다(이때 아래서부터 찾습니다).
+이후, `alert`가 `(**)`에서 `rabbit.eats`프로퍼티를 읽으려 할 때, `rabbit`에서 읽지 않습니다. 즉, 자바스크립트는 `[[Prototype]]`을 따라가서 참조하고 `animal`에서 해당 프로퍼티를 찾아냅니다(이때 아래서부터 찾습니다).
 
 ![](proto-animal-rabbit.svg)
 
 이것을 "`animal`은 `rabbit`의 원형이다"라고 하거나 "`rabbit`은 `animal`으로 부터 원형 상속을 한다."라고 할 수 있습니다.
 
-그래서 만약 `animal`이 많은 유용한 객체와 메서드를 가지고 있다면, `rabbit`에서 자동으로 사용할 수 있게 됩니다. 그런 속성들을 "상속됐다"라고 표현하죠.
+그래서 만약 `animal`이 많은 유용한 객체와 메서드를 가지고 있다면, `rabbit`에서 자동으로 사용할 수 있게 됩니다. 그런 프로퍼티들을 "상속됐다"라고 표현하죠.
 
 만약 우리가 `animal`에 어떤 메서드를 가지고 있다면, `rabbit`에서도 호출할 수 있습니다.
 
@@ -139,9 +139,9 @@ alert(longEar.jumps); // true (from rabbit)
 
 ## Writing doesn't use prototype
 
-원형은 오직 속성들을 읽는 데 사용합니다.
+원형은 오직 프로퍼티들을 읽는 데 사용합니다.
 
-getter/setter가 아닌 데이터 속성들을 쓰고/지우는 명령들은 객체에 직접 적용할 수 있습니다.
+getter/setter가 아닌 데이터 프로퍼티들을 쓰고/지우는 명령들은 객체에 직접 적용할 수 있습니다.
 
 아래 예제에서는, `walk`메서드를 `rabbit`에 할당하고 있습니다:
 
@@ -172,7 +172,7 @@ rabbit.walk(); // Rabbit! Bounce-bounce!
 
 Accessor properties are an exception, as assignment is handled by a setter function. So writing to such a property is actually the same as calling a function.
 
-예를 들어, 아래 코드에서 `admin.fullName`속성을 보시면:
+예를 들어, 아래 코드에서 `admin.fullName`프로퍼티를 보시면:
 
 ```js run
 let user = {
@@ -199,7 +199,7 @@ alert(admin.fullName); // John Smith (*)
 admin.fullName = "Alice Cooper"; // (**)
 ```
 
-여기 `(*)`라인의 `admin.fullName`속성은 `user`원형에서 getter를 가지고 있습니다, 그래서 호출된 것이죠. 그리고 `(**)`라인의 속성은 setter를 원형에 가지고 있습니다. 그렇기 때문에 호출된 것입니다.
+여기 `(*)`라인의 `admin.fullName`프로퍼티는 `user`원형에서 getter를 가지고 있습니다, 그래서 호출된 것이죠. 그리고 `(**)`라인의 프로퍼티는 setter를 원형에 가지고 있습니다. 그렇기 때문에 호출된 것입니다.
 
 ## "this" 값
 

--- a/1-js/08-prototypes/02-function-prototype/article.md
+++ b/1-js/08-prototypes/02-function-prototype/article.md
@@ -10,7 +10,7 @@ JavaScript had prototypal inheritance from the beginning. It was one of the core
 But in the old times, there was no direct access to it. The only thing that worked reliably was a `"prototype"` property of the constructor function, described in this chapter. So there are many scripts that still use it.
 ```
 
-`F.prototype`은 여기서 `F`안에 `"prototype"`이라는 일반적인 속성임을 알아두세요. "원형"이라는 용어랑 비슷하게 들리겠지만, 여기서 진정으로 말하고자 하는 것은 이 이름으로 쓰이는 일반적인 속성입니다.
+`F.prototype`은 여기서 `F`안에 `"prototype"`이라는 일반적인 프로퍼티임을 알아두세요. "원형"이라는 용어랑 비슷하게 들리겠지만, 여기서 진정으로 말하고자 하는 것은 이 이름으로 쓰이는 일반적인 프로퍼티입니다.
 
 예를 들어 보죠:
 
@@ -48,9 +48,9 @@ If, after the creation, `F.prototype` property changes (`F.prototype = <another 
 
 ## 기본 F.prototype, 생성자 속성
 
-우리가 제공하지 않더라도 모든 함수는 "prototype" 속성을 갖습니다.  
+우리가 제공하지 않더라도 모든 함수는 "prototype" 프로퍼티를 갖습니다.  
 
-기본 `"prototype"`은 단 하나의 속성 `constructor`을 갖습니다. 이 속성은 함수 자기 자신을 가리킵니다.  
+기본 `"prototype"`은 단 하나의 프로퍼티 `constructor`을 갖습니다. 이 프로퍼티는 함수 자기 자신을 가리킵니다.  
 
 이렇게 말이죠:
 
@@ -74,7 +74,7 @@ function Rabbit() {}
 alert( Rabbit.prototype.constructor == Rabbit ); // true
 ```
 
-자연적으로, 만약 아무것도 하지 않는다면, `constructor` 속성은 모든 rabbit에서 `[[Prototype]]`을 통해 접근 가능합니다.
+자연적으로, 만약 아무것도 하지 않는다면, `constructor` 프로퍼티는 모든 rabbit에서 `[[Prototype]]`을 통해 접근 가능합니다.
 
 ```js run
 function Rabbit() {}
@@ -88,7 +88,7 @@ alert(rabbit.constructor == Rabbit); // true (from prototype)
 
 ![](rabbit-prototype-constructor.svg)
 
-우리는 이미 존재하는 것과 동일한 `constructor` 속성을 이용해서 새로운 객체를 만들 수 있습니다. 
+우리는 이미 존재하는 것과 동일한 `constructor` 프로퍼티를 이용해서 새로운 객체를 만들 수 있습니다. 
 
 이렇게요:
 
@@ -129,7 +129,7 @@ alert(rabbit.constructor === Rabbit); // false
 */!*
 ```
 
-그래서, `constructor`를 유지하기 위해서는 전체를 덮어쓰기보다는 기본값의 `"prototype"`에서 추가/제거할 속성들을 선택할 수 있습니다. 
+그래서, `constructor`를 유지하기 위해서는 전체를 덮어쓰기보다는 기본값의 `"prototype"`에서 추가/제거할 프로퍼티들을 선택할 수 있습니다. 
 
 ```js
 function Rabbit() {}
@@ -140,7 +140,7 @@ Rabbit.prototype.jumps = true
 // the default Rabbit.prototype.constructor is preserved
 ```
 
-혹은 다른 방법으로,  `constructor`속성을 일일이 재생성시킬 수도 있겠죠.
+혹은 다른 방법으로,  `constructor`프로퍼티를 일일이 재생성시킬 수도 있겠죠.
 
 ```js
 Rabbit.prototype = {
@@ -162,7 +162,7 @@ Rabbit.prototype = {
 
 - `F.prototype` 프로퍼티는 `[[prototype]]`과 다릅니다. `F.prototype` 은 `new F()` 가 호출됐을 때 새로운 객체의 `[[Prototype]]`을 설정하는 일 한 가지만 합니다.
 - `F.prototype` 의 값은 객체이거나 null입니다. 다른 값은 적용이 안 됩니다.
-- `"prototype"` 속성은 특별한 효과만 가지고 있습니다. `new` 와 함께 호출될 때, 생성자 함수로 설정될 때 그 효과가 일어나죠. 
+- `"prototype"` 프로퍼티는 특별한 효과만 가지고 있습니다. `new` 와 함께 호출될 때, 생성자 함수로 설정될 때 그 효과가 일어나죠. 
 
 일반적인 객체의 `prototype`은 전혀 특별하지 않죠.
 ```js
@@ -172,4 +172,4 @@ let user = {
 };
 ```
 
-기본값으로 모든 함수는 `F.prototype = { constructor : F }`를 가지고 있습니다, 그래서 우리는 `"constructor"` 속성을 통해서 어떤 객체의 생성자를 얻을 수 있습니다.
+기본값으로 모든 함수는 `F.prototype = { constructor : F }`를 가지고 있습니다, 그래서 우리는 `"constructor"` 프로퍼티를 통해서 어떤 객체의 생성자를 얻을 수 있습니다.


### PR DESCRIPTION
Property의 번역어는 `속성`이 아니라 `프로퍼티`로 합의함.

* 01-prototype-inheritance
* 02-function-prototype

Issue: #68

---

안녕하세요? 이전 패치에 이어서 프로퍼티 번역어가 일치 하지 않는 부분을 수정해봤습니다. 이 외의 파일들은 주로 HTML attribute를 `속성`으로 번역한 것이거나 객체의 프로퍼티와 무관한 경우들인것 같습니다 (https://github.com/sangwoo108/ko.javascript.info/issues/1). 확인 한번 부탁드리겠습니다. 감사합니다.

P.S. 번역투나 호응 문제 등은 수정하지 않았습니다.