### PR TITLE
camel case 번역어 통일

### DIFF
--- a/1-js/02-first-steps/04-variables/article.md
+++ b/1-js/02-first-steps/04-variables/article.md
@@ -157,7 +157,7 @@ let userName;
 let test123;
 ```
 
-여러 단어를 조합하여 변수명을 만들 땐 [카멜 케이스(camelCase)](https://en.wikipedia.org/wiki/CamelCase)가 흔히 사용됩니다. 카멜 케이스는 단어를 차례대로 나열하면서 첫 단어를 제외한 각 단어의 첫 글자를 대문자로 작성합니다. `myVeryLongName`같이 말이죠.
+여러 단어를 조합하여 변수명을 만들 땐 [카멜 표기법(camelCase)](https://en.wikipedia.org/wiki/CamelCase)가 흔히 사용됩니다. 카멜 표기법은 단어를 차례대로 나열하면서 첫 단어를 제외한 각 단어의 첫 글자를 대문자로 작성합니다. `myVeryLongName`같이 말이죠.
 
 달러 기호 `'$'` 와 밑줄 `'_'` 를 변수명에 사용할 수 있다는 점이 조금 특이하네요. 이 특수 기호는 일반 글자처럼 특별한 의미를 지니진 않습니다.
 

--- a/2-ui/1-document/08-styles-and-classes/article.md
+++ b/2-ui/1-document/08-styles-and-classes/article.md
@@ -86,7 +86,7 @@ elem.style.top = top; // 예시: '456px'
 
 `elem.style` 프로퍼티는 `"style"` 속성에 대응되는 객체입니다. `elem.style.width="100px"`는 `style` 속성값을 문자열 `width:100px`로 설정한 것과 같습니다.
 
-여러 단어를 이어서 만든 프로퍼티는 아래와 같이 카멜 케이스로 이름 지을 수 있습니다.
+여러 단어를 이어서 만든 프로퍼티는 아래와 같이 카멜 표기법으로 이름 지을 수 있습니다.
 
 ```js no-beautify
 background-color  => elem.style.backgroundColor
@@ -101,7 +101,7 @@ document.body.style.backgroundColor = prompt('배경은 무슨 색인가요?', '
 ```
 
 ````smart header="브라우저 지정 프로퍼티"
-`-moz-border-radius`, `-webkit-border-radius`같이 브라우저에서 미리 지정한 프로퍼티 역시 카멜 케이스를 사용합니다. 대시(-)는 대문자로 해석하면 됩니다.
+`-moz-border-radius`, `-webkit-border-radius`같이 브라우저에서 미리 지정한 프로퍼티 역시 카멜 표기법을 사용합니다. 대시(-)는 대문자로 해석하면 됩니다.
 
 예시:
 
@@ -294,7 +294,7 @@ JavaScript may not see the styles applied by `:visited`. And also, there's a lim
 
 스타일 변경 방법:
 
-- `style` 프로퍼티는 카멜 케이스를 이용해 변경한 스타일이 있는 객체로, 이 객체를 조작하는 것은 `"style"` 속성과 대응하는 개별 프로퍼티를 조작하는 것과 같습니다. `important` 등의 규칙을 어떻게 적용할 수 있는지 알아보려면 [MDN](mdn:api/CSSStyleDeclaration)에서 관련 메서드를 살펴보시기 바랍니다. 
+- `style` 프로퍼티는 카멜 표기법을 이용해 변경한 스타일이 있는 객체로, 이 객체를 조작하는 것은 `"style"` 속성과 대응하는 개별 프로퍼티를 조작하는 것과 같습니다. `important` 등의 규칙을 어떻게 적용할 수 있는지 알아보려면 [MDN](mdn:api/CSSStyleDeclaration)에서 관련 메서드를 살펴보시기 바랍니다. 
 
 - `style.cssText` 프로퍼티는 `"style"` 속성 전체에 대응하므로 스타일 전체에 대한 문자열이 저장됩니다.
 


### PR DESCRIPTION
camel case의 번역어가 카멜 케이스와 카멜 표기법으로 혼용되던 것을 카멜 표기법으로 통일했습니다.(이전 커밋에 문제가 생겨 다시 올립니다)

````diff
-카멜 케이스
+카멜 표기법
````

# Pull Request 체크리스트
## TODO
- [x] [번역 규칙을 확인하셨나요?](https://github.com/javascript-tutorial/ko.javascript.info#%EB%B2%88%EC%97%AD-%EA%B7%9C%EC%B9%99)
  - [x] 줄 바꿈과 단락을 '원문과 동일하게' 유지하셨나요?
  - [x] [맞춤법 검사기](http://speller.cs.pusan.ac.kr/)로 맞춤법을 확인하셨나요?
  - [x] 마크다운 문법에 사용되는 공백(스페이스), 큰따옴표("), 작은따옴표('), 대시(-), 백틱(`) 등의 특수문자는 그대로 두셨나요?
- [x] [로컬 서버 세팅](https://github.com/javascript-tutorial/ko.javascript.info/wiki/%EB%A1%9C%EC%BB%AC-%EC%84%9C%EB%B2%84-%EC%84%B8%ED%8C%85%ED%95%98%EA%B8%B0) 후 최종 결과물을 확인해 보셨나요?
- [x] PR 하나엔 번역문 하나만 넣으셨나요?
- [x] 의미 있는 커밋 메시지를 작성하셨나요?
  - 예시
    - [프락시] 번역
    - [프락시] 과제 번역
    - [if문과 조건부 연산자 '?'] 리뷰
    - [주석] 2차 리뷰
    - [Date 객체와 날짜] 번역
