### PR TITLE
[private, protected 프로퍼티와 메서드] 읽기 전용 프로퍼티 예제 SyntaxError 수정

### DIFF
--- a/1-js/09-classes/04-private-protected-properties-methods/article.md
+++ b/1-js/09-classes/04-private-protected-properties-methods/article.md
@@ -144,9 +144,9 @@ class CoffeeMachine {
 // 커피 머신 생성
 let coffeeMachine = new CoffeeMachine(100);
 
-alert(``전력량이 ${power}인 커피머신을 만듭니다.W`); // 전력량이 100인 커피머신을 만듭니다.
+alert(`전력량이 ${coffeeMachine.power}인 커피머신을 만듭니다.`); // 전력량이 100인 커피머신을 만듭니다.
 
-coffeeMachine.power = 25; // TypeError (setter 없음)
+coffeeMachine.power = 25; // Error (setter 없음)
 ```
 
 ````smart header="getter와 setter 함수"


### PR DESCRIPTION
#106 Pull Request 체크리스트
## TODO
- [x] [번역 규칙을 확인하셨나요?](https://github.com/javascript-tutorial/ko.javascript.info#%EB%B2%88%EC%97%AD-%EA%B7%9C%EC%B9%99)
  - [x] 줄 바꿈과 단락을 '원문과 동일하게' 유지하셨나요?
  - [x] [맞춤법 검사기](http://speller.cs.pusan.ac.kr/)로 맞춤법을 확인하셨나요?
  - [x] 마크다운 문법에 사용되는 공백(스페이스), 큰따옴표("), 작은따옴표('), 대시(-), 백틱(`) 등의 특수문자는 그대로 두셨나요?
- [x] [로컬 서버 세팅](https://github.com/javascript-tutorial/ko.javascript.info/wiki/%EB%A1%9C%EC%BB%AC-%EC%84%9C%EB%B2%84-%EC%84%B8%ED%8C%85%ED%95%98%EA%B8%B0) 후 최종 결과물을 확인해 보셨나요?
- [x] PR 하나엔 번역문 하나만 넣으셨나요?
- [x] 의미 있는 커밋 메시지를 작성하셨나요?
  - 예시
    - [프락시] 번역
    - [프락시] 과제 번역
    - [if문과 조건부 연산자 '?'] 리뷰
    - [주석] 2차 리뷰
    - [Date 객체와 날짜] 번역

### Related Issue: #556  

### NOTE

> 읽기 전용 프로퍼티 예제
> SyntaxError: missing ) after argument list 에러 발생
>
> private 프로퍼티 예제
> SyntaxError: Unexpected token '('
>
> #waterAmount 생성 예제
> SyntaxError: Private field '#waterAmount' must be declared in an enclosing class

1. 원래 이슈에 있던 3가지의 에러 케이스 중 첫번째 에러만 문제가 있다고 판단하여 첫번째 에러에 대해서만 동작할 수 있게끔 수정하였습니다. 
2. 영어 원문에 에러가 TypeError 가 아니라 Error 로 표기되어 있어 TypeError -> Error 로 수정합니다.