### PR TITLE
[정규식 앵커] 본문 및 과제 번역

### DIFF
--- a/9-regular-expressions/04-regexp-anchors/1-start-end/solution.md
+++ b/9-regular-expressions/04-regexp-anchors/1-start-end/solution.md
@@ -1,5 +1,5 @@
-An empty string is the only match: it starts and immediately finishes.
+유일하게 일치하는 문자열은 빈 문자열입니다. 시작하자마자 바로 끝나는 문자열이죠.
 
-The task once again demonstrates that anchors are not characters, but tests.
+이번 과제로 다시 한번 앵커는 문자가 아니라 조건을 표현한다는 것을 알 수 있습니다.
 
-The string is empty `""`. The engine first matches the `pattern:^` (input start), yes it's there, and then immediately the end `pattern:$`, it's here too. So there's a match.
+여기 빈 문자열 `""`이 있습니다. 정규식 엔진은 먼저 입력의 시작 `pattern:^`를 확인합니다. 문자열이 시작했네요. 그리고 바로 입력의 끝 `pattern:$`를 확인합니다. 끝도 바로 있네요. 그래서 결과는 일치입니다.

--- a/9-regular-expressions/04-regexp-anchors/1-start-end/task.md
+++ b/9-regular-expressions/04-regexp-anchors/1-start-end/task.md
@@ -1,3 +1,3 @@
-# Regexp ^$
+# 정규식 ^$
 
-Which string matches the pattern `pattern:^$`?
+`pattern:^$`와 일치하는 문자열은 어떤 문자열일까요?

--- a/9-regular-expressions/04-regexp-anchors/article.md
+++ b/9-regular-expressions/04-regexp-anchors/article.md
@@ -1,34 +1,34 @@
-# Anchors: string start ^ and end $
+# 앵커: 문자열의 시작 ^과 끝 $
 
-The caret `pattern:^` and dollar `pattern:$` characters have special meaning in a regexp. They are called "anchors".
+캐럿(caret) 기호 `pattern:^`와 달러 기호 `pattern:$`는 정규식에서 특별한 뜻을 지닙니다. 두 기호를 '앵커(anchor)'라고 합니다.
 
-The caret `pattern:^` matches at the beginning of the text, and the dollar `pattern:$` -- at the end.
+캐럿 기호 `pattern:^`는 텍스트의 시작, 달러 기호 `pattern:$`는 텍스트의 끝을 나타냅니다.
 
-For instance, let's test if the text starts with `Mary`:
+텍스트가 `Mary`로 시작하는지 검사해보죠.
 
 ```js run
 let str1 = "Mary had a little lamb";
 alert( /^Mary/.test(str1) ); // true
 ```
 
-The pattern `pattern:^Mary` means: "string start and then Mary".
+`pattern:^Mary` 패턴은 "문자열이 시작하고 바로 Mary가 나타난다"라는 뜻입니다.
 
-Similar to this, we can test if the string ends with `snow` using `pattern:snow$`:
+위와 유사하게 `pattern:snow$`를 사용해서 문자열이 `snow`로 끝나는지 검사할 수 있습니다.
 
 ```js run
 let str1 = "it's fleece was white as snow";
 alert( /snow$/.test(str1) ); // true
 ```
 
-In these particular cases we could use string methods `startsWith/endsWith` instead. Regular expressions should be used for more complex tests.
+지금까지 살펴본 예시에서는 앵커를 사용하는 대신 문자열 메서드 `startsWith·endsWith`를 사용해도 같은 결과를 얻을 수 있습니다. 정규 표현식은 좀 더 복잡한 검사가 필요할 때 사용하도록 합시다.
 
-## Testing for a full match
+## 완전히 일치하는지 검사하기
 
-Both anchors together `pattern:^...$` are often used to test whether or not a string fully matches the pattern. For instance, to check if the user input is in the right format.
+두 앵커를 같이 쓰는 `pattern:^...$`는 문자열이 패턴과 완전히 일치하는지 확인할 때 자주 사용됩니다. 사용자가 입력한 내용이 올바른 형식으로 되어있는지 확인할 때가 대표적인 예입니다.
 
-Let's check whether or not a string is a time in `12:34` format. That is: two digits, then a colon, and then another two digits.
+문자열이 `12:34` 형식의 시간인지 확인해봅시다. 즉, 숫자 두 개 뒤에 콜론이 나오고 다시 숫자 두 개가 나오는 형식인지 확인해보는 것입니다.
 
-In regular expressions language that's `pattern:\d\d:\d\d`:
+정규 표현식으로 쓰면 `pattern:\d\d:\d\d`가 되겠네요.
 
 ```js run
 let goodInput = "12:34";
@@ -39,14 +39,14 @@ alert( regexp.test(goodInput) ); // true
 alert( regexp.test(badInput) ); // false
 ```
 
-Here the match for `pattern:\d\d:\d\d` must start exactly after the beginning of the text `pattern:^`, and the end `pattern:$` must immediately follow.
+예시에서 `pattern:\d\d:\d\d`와 일치하는 문자열은 반드시 텍스트의 시작인 `pattern:^` 바로 다음에 나와야 하고 그 뒤에 바로 텍스트의 끝 `pattern:$`가 나와야 합니다.
 
-The whole string must be exactly in this format. If there's any deviation or an extra character, the result is `false`.
+문자열 전체가 이 형식에 정확히 일치해야 합니다. 형식에서 벗어난 문자가 있거나 문자가 더 많으면 결과는 `false`입니다.
 
-Anchors behave differently if flag `pattern:m` is present. We'll see that in the next article.
+앵커는 `pattern:m` 플래그가 있을 때는 다르게 동작하는데요. 어떻게 다른지는 다음 글에서 살펴보겠습니다.
 
-```smart header="Anchors have \"zero width\""
-Anchors `pattern:^` and `pattern:$` are tests. They have zero width.
+```smart header="앵커의 너비는 '0'"
+앵커 `pattern:^`와 `pattern:$`는 조건을 나타냅니다. 따라서 앵커의 너비는 0입니다.
 
-In other words, they do not match a character, but rather force the regexp engine to check the condition (text start/end).
+다시 말해서 앵커는 어떤 문자와 일치하는 것이 아니라 정규식 엔진이 문자열의 시작과 끝이라는 조건을 검사하도록 강제하는 역할을 합니다.
 ```


### PR DESCRIPTION
캐럿 기호 `^`의 경우 삿갓표라는 명칭이 공식 명칭은 아니어서 캐럿 기호로 번역했습니다.
