### PR TITLE
[오타수정] Part 1.11.2 Promise (#1683)

### DIFF
--- a/1-js/11-async/02-promise-basics/article.md
+++ b/1-js/11-async/02-promise-basics/article.md
@@ -60,7 +60,7 @@ let promise = new Promise(function(resolve, reject) {
 1. executor는 `new Promise`에 의해 자동으로 그리고 즉각적으로 호출됩니다.
 2. executor는 인자로 `resolve`와 `reject` 함수를 받습니다. 이 함수들은 자바스크립트 엔진이 미리 정의한 함수이므로 개발자가 따로 만들 필요가 없습니다. 다만, `resolve`나 `reject` 중 하나는 반드시 호출해야 합니다.
 
-    executor '처리'가 시작 된 지 1초 후, `resolve("done")`이 호출되고 결과가 만들어집니다. 이때 `promise` 객체의 상태는 다음과 같이 변합니다.
+    executor '처리'가 시작 된 지 1초 후, `resolve("완료")`이 호출되고 결과가 만들어집니다. 이때 `promise` 객체의 상태는 다음과 같이 변합니다.
 
     ![](promise-resolve-1.svg)
 


### PR DESCRIPTION
# 요약

[프로미스](https://ko.javascript.info/promise-basics)
<img width="914" alt="스크린샷 2023-01-18 오후 11 43 07" src="https://user-images.githubusercontent.com/32788900/213201070-d9de2dd5-f0e9-41f6-b4ea-e4ffa4e191e8.png">

상단 코드와 하단 다이어그램에는 모두 `resolve("완료")` 라고 되어있지만, 설명문에는 `resolve("done")` 이라고 되어있습니다.


# 연관 이슈
(fix #1683)

# Pull Request 체크리스트
## TODO
- [x] [번역 규칙을 확인하셨나요?](https://github.com/javascript-tutorial/ko.javascript.info#%EB%B2%88%EC%97%AD-%EA%B7%9C%EC%B9%99)
  - [x] 줄 바꿈과 단락을 '원문과 동일하게' 유지하셨나요?
  - [x] [맞춤법 검사기](http://speller.cs.pusan.ac.kr/)로 맞춤법을 확인하셨나요?
  - [x] 마크다운 문법에 사용되는 공백(스페이스), 큰따옴표("), 작은따옴표('), 대시(-), 백틱(`) 등의 특수문자는 그대로 두셨나요?
- [x] [로컬 서버 세팅](https://github.com/javascript-tutorial/ko.javascript.info/wiki/%EB%A1%9C%EC%BB%AC-%EC%84%9C%EB%B2%84-%EC%84%B8%ED%8C%85%ED%95%98%EA%B8%B0) 후 최종 결과물을 확인해 보셨나요?
- [x] PR 하나엔 번역문 하나만 넣으셨나요?
- [x] 의미 있는 커밋 메시지를 작성하셨나요?
  - 예시
    - [프락시] 번역
    - [프락시] 과제 번역
    - [if문과 조건부 연산자 '?'] 리뷰
    - [주석] 2차 리뷰
    - [Date 객체와 날짜] 번역
