### PR TITLE
[WIP] [문서번역] network > xmlhttprequest examples

### DIFF
--- a/5-network/08-xmlhttprequest/example.view/index.html
+++ b/5-network/08-xmlhttprequest/example.view/index.html
@@ -25,6 +25,6 @@ function write(text) {
 }
 </script>
 
-<button onclick="run()">Load digits</button>
+<button onclick="run()">숫자 불러오기</button>
 
 <ul id="log"></ul>

--- a/5-network/08-xmlhttprequest/hello.txt
+++ b/5-network/08-xmlhttprequest/hello.txt
@@ -1,1 +1,1 @@
-Hello from the server!
+서버에서 보낸 인사입니다!

--- a/5-network/08-xmlhttprequest/phones-async.view/index.html
+++ b/5-network/08-xmlhttprequest/phones-async.view/index.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 
-  <button onclick="loadPhones()" id="button">Load phones.json!</button>
+  <button onclick="loadPhones()" id="button">phones.json 불러오기!</button>
 
   <script>
     function loadPhones() {
@@ -21,19 +21,19 @@
       xhr.onreadystatechange = function() {
         if (xhr.readyState != 4) return;
 
-        button.innerHTML = 'Complete!';
+        button.innerHTML = '완료!';
 
         if (xhr.status != 200) {
-          // handle error
+          // 에러 처리
           alert(xhr.status + ': ' + xhr.statusText);
         } else {
-          // show result
+          // 결과 표시
           alert(xhr.responseText);
         }
 
       }
 
-      button.innerHTML = 'Loading...';
+      button.innerHTML = '로딩 중...';
       button.disabled = true;
     }
   </script>

--- a/5-network/08-xmlhttprequest/phones.view/index.html
+++ b/5-network/08-xmlhttprequest/phones.view/index.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 
-  <button onclick="loadPhones()">Load phones.json!</button>
+  <button onclick="loadPhones()">phones.json 불러오기!</button>
 
   <script>
     function loadPhones() {
@@ -15,10 +15,10 @@
       xhr.send();
 
       if (xhr.status != 200) {
-        // handle error
-        alert('Error ' + xhr.status + ': ' + xhr.statusText);
+        // 에러 처리
+        alert('에러 ' + xhr.status + ': ' + xhr.statusText);
       } else {
-        // show result
+        // 결과 표시
         alert(xhr.responseText);
       }
     }

--- a/5-network/08-xmlhttprequest/phones.view/server.js
+++ b/5-network/08-xmlhttprequest/phones.view/server.js
@@ -10,7 +10,7 @@ let file = new static.Server('.', {
 function accept(req, res) {
 
   if (req.url == '/phones.json') {
-    // stall a bit to let "loading" message show up
+    // '로딩 중' 메시지를 표시하기 위해 잠시 지연
     setTimeout(function() {
       file.serve(req, res);
     }, 2000);

--- a/5-network/08-xmlhttprequest/post.view/index.html
+++ b/5-network/08-xmlhttprequest/post.view/index.html
@@ -12,13 +12,13 @@
 		const chunk = await reader.read();
 
 		if (chunk.done) {
-			console.log("done!");
+			console.log("완료!");
 			break;
 		}
 
 		chunks.push(chunk.value);
 		receivedLength += chunk.value.length;
-		console.log(`${receivedLength}/${contentLength} received`)
+		console.log(`${receivedLength}/${contentLength} 수신`)
 	}
 
 

--- a/5-network/08-xmlhttprequest/post.view/server.js
+++ b/5-network/08-xmlhttprequest/post.view/server.js
@@ -17,7 +17,7 @@ function accept(req, res) {
       chunks.push(data);
       length += data.length;
 
-      // More than 10mb, kill the connection!
+      // 10mb를 넘으면 연결을 종료합니다!
       if (length > 1e8) {
         req.connection.destroy();
       }
@@ -28,16 +28,16 @@ function accept(req, res) {
 
       if (req.url == '/user') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ message: 'User saved' }));
+        res.end(JSON.stringify({ message: '사용자 저장 완료' }));
       } else if (req.url == '/image') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ message: "Image saved", imageSize: length }));
+        res.end(JSON.stringify({ message: "이미지 저장 완료", imageSize: length }));
       } else if (req.url == '/upload') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ message: "Upload complete", size: length }));
+        res.end(JSON.stringify({ message: "업로드 완료", size: length }));
       } else {
         res.writeHead(404);
-        res.end("Not found");
+        res.end("찾을 수 없음");
       }
     });
 


### PR DESCRIPTION
# 요약
`5-network/08-xmlhttprequest` 하위 예제 파일의 사용자 노출 문자열과 짧은 주석을 한국어로 번역했습니다.

- `example.view`, `phones.view`, `phones-async.view`, `post.view` 예제의 버튼, alert, console, 응답 메시지 번역
- `hello.txt` 서버 응답 예제 문자열 번역
- 코드 구조와 JavaScript 문자열 구분자는 원문 코드 스타일을 유지

# 연관 이슈
관련 #1864

# Pull Request 체크리스트
## TODO
- [x] [번역 규칙을 확인하셨나요?](https://github.com/javascript-tutorial/ko.javascript.info#%EB%B2%88%EC%97%AD-%EA%B7%9C%EC%B9%99)
  - [x] 줄 바꿈과 단락을 원문과 동일하게 유지하셨나요?
  - [ ] [맞춤법 검사기](http://speller.cs.pusan.ac.kr/)로 맞춤법을 확인하셨나요?
  - [x] 마크다운 문법에 사용되는 공백(스페이스), 큰따옴표("), 작은따옴표('), 대시(-), 백틱(`) 등의 특수문자는 그대로 두셨나요?
- [ ] [로컬 서버 세팅](https://github.com/javascript-tutorial/ko.javascript.info/wiki/%EB%A1%9C%EC%BB%AC-%EC%84%9C%EB%B2%84-%EC%84%B8%ED%8C%85%ED%95%98%EA%B8%B0) 후 최종 결과물을 확인해 보셨나요?
- [x] PR 하나엔 번역문 하나만 넣으셨나요?
- [x] 의미 있는 커밋 메시지를 작성하셨나요?